### PR TITLE
#26 Nuevos valores definidos para genero ENUM en films

### DIFF
--- a/database/migrations/2026_02_16_151203_update_gender_values_in_films_table.php
+++ b/database/migrations/2026_02_16_151203_update_gender_values_in_films_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('films', function (Blueprint $table) {
+        $table->enum('genre', ['suspenso', 'acción', 'drama', 'amor'])->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('films', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
Creamos una nueva migración para actualizar los datos en la columna genero de la tabla films con estos valores:
suspenso, acción, drama y amor

Primero creamos la migración con este comando y le damos este nombre:
php artisan make:migration update_gender_values_in_films_table --table=films

Editamos el archivo de migración pendiente de lanzar, y aplicamos los cambios con este código:
<img width="575" height="191" alt="Image" src="https://github.com/user-attachments/assets/59c42e0e-3ca6-4a80-a7ba-e31cdcb0fa3f" />

Guardamos los cambios y lanzamos la migración pendiente: php artisan migrate
<img width="539" height="50" alt="Image" src="https://github.com/user-attachments/assets/6fe98d57-1092-4866-9a95-2f350f0dd085" />

Comprobamos los cambios en la BBDD:
<img width="587" height="156" alt="Image" src="https://github.com/user-attachments/assets/dbff1ce5-2bff-4dc2-9768-b6dd85dccf56" />

Ahora tenemos una lista de los tipos de géneros que podemos usar, si no se cumple lo bloqueará la BBDD.